### PR TITLE
Flyway upgrade from version 5.2.4 to 6.0.0

### DIFF
--- a/flyway-commandline/pom.xml
+++ b/flyway-commandline/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>5.2.4-eveoh1</version>
+        <version>6.0.0-eveoh1</version>
     </parent>
     <artifactId>flyway-commandline</artifactId>
     <packaging>jar</packaging>

--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>5.2.4-eveoh1</version>
+        <version>6.0.0-eveoh1</version>
     </parent>
     <artifactId>flyway-core</artifactId>
     <packaging>jar</packaging>

--- a/flyway-gradle-plugin/pom.xml
+++ b/flyway-gradle-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>5.2.4-eveoh1</version>
+        <version>6.0.0-eveoh1</version>
     </parent>
     <artifactId>flyway-gradle-plugin</artifactId>
     <packaging>jar</packaging>

--- a/flyway-maven-plugin/pom.xml
+++ b/flyway-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-parent</artifactId>
-        <version>5.2.4-eveoh1</version>
+        <version>6.0.0-eveoh1</version>
     </parent>
     <artifactId>flyway-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.flywaydb</groupId>
     <artifactId>flyway-parent</artifactId>
-    <version>5.2.4-eveoh1</version>
+    <version>6.0.0-eveoh1</version>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <description>Flyway: Database Migrations Made Easy.</description>


### PR DESCRIPTION
Ref. #???

## Proposed changes

Upgrade Flyway version from 5.2.4 to 6.0.0 for the upcoming Spring Boot 2.2 upgrade in MyTimetable.

## Testing

N/A

## Documentation

N/A

## Upgrade notes for breaking changes

- [ ] `UPGRADE_NOTES.md` has been updated (when applicable).
